### PR TITLE
Added semantic release branches definition

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,4 +1,5 @@
 {
+  "branches": [{ "name": "main" }],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",


### PR DESCRIPTION
Added semantic release branches definition, branch `main` not covered by default setup.