### PR TITLE
Ignore commits auto-generated by semantic-release for releases

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ["@commitlint/config-conventional"],
+  ignores: [(message) => message.startsWith("chore(release)")],
 };


### PR DESCRIPTION
Ignore commits auto-generated by semantic-release for releases, they may have length > 100 chars since they group together a lot of commits or changes.