### PR TITLE
fix: 🐛 fixed ci release loop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Commit Changes
         if: steps.code-format.outputs.formatted-files > 0
         run: |
-          git commit -m "refactor: 💡 Clean code" -a
+          git commit -m "refactor: 💡 Clean code [skip ci]" -a
 
       - name: Unit tests
         run: |
@@ -64,7 +64,7 @@ jobs:
       - name: Commit Changes
         if: steps.generate-docs.outputs.generated-docs > 0
         run: |
-          git commit -m "docs: ✏️ Updated StoryBook" -a
+          git commit -m "docs: ✏️ Updated StoryBook [skip ci]" -a
 
       - name: Test runner
         run: |


### PR DESCRIPTION
Fixed infinite release loop caused by automatic commits (docs, formatting) triggering new pipeline runs. Added 'skip ci' to commit messages to prevent re-triggering.